### PR TITLE
ci: enforce GitHub Actions security posture with zizmor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24.x
       - name: Set up PNPM

--- a/.github/workflows/dependency-diff-analyze.yml
+++ b/.github/workflows/dependency-diff-analyze.yml
@@ -1,0 +1,34 @@
+name: Dependency Diff (Analyze)
+
+on:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  diff-dependencies:
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Analyze dependencies
+        id: analyze
+        uses: e18e/action-dependency-diff@8e9b8c1957ab066d36235a43f4c1ff1522e1bdbc # v1.6.1
+        with:
+          mode: artifact
+          # Too noisy. Will enable if it ever supports reporting *changes* in duplicates.
+          duplicate-threshold: '999'
+          # Always report size diff.
+          size-threshold: '-1'
+
+      - name: Upload artifact
+        if: steps.analyze.outputs.artifact-path
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: e18e-diff-result
+          path: ${{ steps.analyze.outputs.artifact-path }}

--- a/.github/workflows/dependency-diff.yml
+++ b/.github/workflows/dependency-diff.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: e18e/action-dependency-diff@v1
         with:
           # Too noisy. Will enable if it ever supports reporting *changes* in duplicates.

--- a/.github/workflows/dependency-diff.yml
+++ b/.github/workflows/dependency-diff.yml
@@ -1,24 +1,29 @@
-name: Dependency Diff
+name: Dependency Diff (Comment)
 
-on:
-  pull_request:
+on: # zizmor: ignore[dangerous-triggers] -- The whole point of this is that it's secure.
+  workflow_run:
+    workflows: ['Dependency Diff (Analyze)']
+    types:
+      - completed
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 jobs:
-  dependency-diff:
-    runs-on: ubuntu-latest
-
+  post-comment:
+    runs-on: ubuntu-slim
+    if: github.event.workflow_run.conclusion == 'success'
+    permissions:
+      pull-requests: write # posts comments
+      actions: read # reads artifact from previous workflow
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Download artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          fetch-depth: 0
-          persist-credentials: false
-      - uses: e18e/action-dependency-diff@8e9b8c1957ab066d36235a43f4c1ff1522e1bdbc # v1
+          name: e18e-diff-result
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Post comment
+        uses: e18e/action-dependency-diff@8e9b8c1957ab066d36235a43f4c1ff1522e1bdbc # v1.6.1
         with:
-          # Too noisy. Will enable if it ever supports reporting *changes* in duplicates.
-          duplicate-threshold: '999'
-          # Always report size diff.
-          size-threshold: '-1'
+          mode: comment-from-artifact
+          artifact-path: e18e-diff-result.json

--- a/.github/workflows/dependency-diff.yml
+++ b/.github/workflows/dependency-diff.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: e18e/action-dependency-diff@v1
+      - uses: e18e/action-dependency-diff@8e9b8c1957ab066d36235a43f4c1ff1522e1bdbc # v1
         with:
           # Too noisy. Will enable if it ever supports reporting *changes* in duplicates.
           duplicate-threshold: '999'

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24.x
       - name: Set up PNPM

--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24.x
       - name: Set up PNPM

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24.x
       - name: Set up PNPM

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24.x
       - name: Set up PNPM

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24.x
       - name: Set up PNPM

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,38 @@
+# https://docs.zizmor.sh/
+name: zizmor
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  merge_group:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: 🔐 GitHub Actions security analysis
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read # checkout repository
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          persona: pedantic
+          # Use annotations instead of SARIF as this doesn't need special permissions
+          annotations: true
+          advanced-security: false

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,8 @@
+# https://docs.zizmor.sh/configuration/
+# $schema: 'https://github.com/zizmorcore/zizmor/blob/v1.25.2/support/zizmor.schema.json'
+
+rules:
+  anonymous-definition:
+    disable: true
+  concurrency-limits:
+    disable: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,3 +57,28 @@ pnpm vitest run app/utils/getCacheAnalysis.test.ts
 ### Styling
 
 UnoCSS utility classes and shortcuts (defined in `uno.config.ts`). Component-specific styles use scoped CSS. Dark mode uses `:is(.dark)` selectors in scoped styles and `dark:` prefix for UnoCSS utilities.
+
+### GitHub Actions security analysis
+
+CI runs [zizmor](https://docs.zizmor.sh/) against the repository's GitHub Actions workflows. The
+shared policy lives in `.github/zizmor.yml`, and the `zizmor` task uses the same pedantic persona as
+CI.
+
+You may run it locally by [installing `zizmor`](https://docs.zizmor.sh/installation/) and running:
+
+```bash
+pnpm run zizmor
+```
+
+Some audits resolve action refs and vulnerability metadata through GitHub. To run those online
+checks locally, authenticate with the GitHub CLI and pass its token:
+
+```bash
+GH_TOKEN="$(gh auth token)" pnpm run zizmor
+```
+
+To fix audit findings automatically, run:
+
+```bash
+GH_TOKEN="$(gh auth token)" pnpm run zizmor:fix
+```

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -23,5 +23,5 @@ export default {
   },
   ignoreFiles: ['uno.config.ts'],
   ignoreDependencies: ['vue', 'vue-router', 'vue-tsc', 'vitest-environment-nuxt'],
-  ignoreBinaries: [],
+  ignoreBinaries: ['zizmor'],
 } satisfies KnipConfig

--- a/package.json
+++ b/package.json
@@ -6,17 +6,19 @@
   "scripts": {
     "build": "nuxt build",
     "dev": "nuxt dev",
-    "generate": "nuxt generate",
-    "lint": "oxlint",
-    "lint:fix": "oxlint --fix",
     "format": "oxfmt",
     "format:check": "oxfmt --check",
+    "generate": "nuxt generate",
+    "knip": "knip",
+    "lint": "oxlint",
+    "lint:fix": "oxlint --fix",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
     "test:unit": "vitest run",
-    "knip": "knip",
     "test": "pnpm run typecheck && pnpm run lint && pnpm run format:check && pnpm run test:unit",
-    "typecheck": "nuxi typecheck"
+    "typecheck": "nuxi typecheck",
+    "zizmor": "zizmor --pedantic .",
+    "zizmor:fix": "zizmor --pedantic --fix ."
   },
   "dependencies": {
     "@netlify/blobs": "^10.7.0",


### PR DESCRIPTION
GitHub Actions workflows are a common attack vector for GitHub projects and their maintainers.

https://zizmor.sh/ implements a number of valuable checks that flag vulnerable patterns immediately on PRs, preventing them from reaching main.

- Apply principle of least privilege by always applying permissions to the exact step or job that actually needs it
- Document why each permission is needed with a comment
- Pin all actions and images to a specific commit or digest
  - Require inline comment with human-friendly version/release identifier
  - Require this identifier to actually match the commit/digest
- Use persist-credentials: false for actions/checkout (by default it persists a GitHub token for later git command; disabling this decreases risk of credentials exposure through logs, disk, etc.)